### PR TITLE
Fix(logic): comparison napalm lag filter

### DIFF
--- a/addons/sourcemod/scripting/FixNapalmLag.sp
+++ b/addons/sourcemod/scripting/FixNapalmLag.sp
@@ -13,7 +13,7 @@ public Plugin myinfo =
 	name = "Napalm Lag Fix",
 	author = "GoD-Tony + BotoX",
 	description = "Prevents lag when napalm is used on players",
-	version = "1.0.5",
+	version = "1.0.6",
 	url = "https://forums.alliedmods.net/showthread.php?t=188093"
 };
 
@@ -59,7 +59,7 @@ public MRESReturn Hook_RadiusDamage(DHookParam hParams)
 		return MRES_Ignored;
 
 	// Block napalm damage if it's coming from another client.
-	if (1 <= iEntIgnore <= MaxClients)
+	if (iEntIgnore >= 1 && iEntIgnore <= MaxClients)
 		return MRES_Supercede;
 
 	// Block napalm that comes from grenades


### PR DESCRIPTION
## Pull request description:
This PR fixes a logic bug in the napalm lag filter where a chained comparison was used to check if iEntIgnore is a valid client index. In SourcePawn, chained comparisons do not behave as mathematical inequalities, which caused the condition to always evaluate as true.

Replaces the chained comparison with a proper logical conjunction:
`if (iEntIgnore >= 1 && iEntIgnore <= MaxClients)`
Ensures only client-originated napalm damage is blocked
Prevents unintended suppression of other burn damage sources
This resolves incorrect damage filtering and restores intended plugin behavior. 
Full details: #21 